### PR TITLE
Updated dependencies to newest and Tesseract to 4.1.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ libpng-*
 tesseract-*
 .vscode
 .swiftpm
+libtesseract.xcframework

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,31 +4,31 @@ vars:
   SRC_DIR:
     sh: pwd
   
-  PNG_VERSION: 1.6.36
+  PNG_VERSION: 1.6.37
   PNG_NAME: libpng-{{.PNG_VERSION}}
   PNG_SRC: "{{.SRC_DIR}}/{{.PNG_NAME}}"
   PNG_ARCHIVE: libpng.a
   PNG_CONFIG: "{{.PNG_SRC}}/configure"
 
-  JPEG_SRC_NAME: jpegsrc.v9c
-  JPEG_DIR_NAME: jpeg-9c # folder name after the JPEG_SRC_NAME archive has been unpacked
+  JPEG_SRC_NAME: jpegsrc.v9e
+  JPEG_DIR_NAME: jpeg-9e # folder name after the JPEG_SRC_NAME archive has been unpacked
   JPEG_SRC:  "{{.SRC_DIR}}/{{.JPEG_DIR_NAME}}"
   JPEG_ARCHIVE: libjpeg.a
   JPEG_CONFIG: "{{.JPEG_SRC}}/configure"
 
-  TIFF_NAME: tiff-4.0.10
+  TIFF_NAME: tiff-4.3.0
   TIFF_SRC:  "{{.SRC_DIR}}/{{.TIFF_NAME}}"
   TIFF_ARCHIVE: libtiff.a
   TIFF_CONFIG: "{{.TIFF_SRC}}/configure"
 
-  TESSERACT_VERSION: 4.1.0
+  TESSERACT_VERSION: 4.1.3
   TESSERACT_NAME: tesseract-{{.TESSERACT_VERSION}}
   TESSERACT_SRC: "{{.SRC_DIR}}/{{.TESSERACT_NAME}}"
   TESSERACT_ARCHIVE: libtesseract.a
   TESSERACT_AUTOGEN: "{{.TESSERACT_SRC}}/autogen.sh"
   TESSERACT_CONFIG: "{{.TESSERACT_SRC}}/configure"
 
-  LEPTONICA_VERSION: 1.79.0
+  LEPTONICA_VERSION: 1.82.0
   LEPTONICA_NAME: leptonica-{{.LEPTONICA_VERSION}}
   LEPTONICA_SRC:  "{{.SRC_DIR}}/{{.LEPTONICA_NAME}}"
   LEPTONICA_ARCHIVE: liblept.a
@@ -111,10 +111,31 @@ tasks:
       - task: clean-artifacts
       - rm -rf {{.PNG_SRC}} {{.TIFF_SRC}} {{.JPEG_SRC}} {{.LEPTONICA_SRC}} {{.TESSERACT_SRC}}
 
+  build-tesseract-ios-xcframework-zip:
+    cmds:
+      - task: build-tesseract-ios-xcframework
+      - zip -r libtesseract-ios-{{.TESSERACT_VERSION}}.xcframework.zip libtesseract.xcframework
+
   build-tesseract-xcframework-zip:
     cmds:
       - task: build-tesseract-xcframework
-      - zip -r libtesseract-{{.RELEASE_VERSION}}.xcframework.zip libtesseract.xcframework
+      - zip -r libtesseract-{{.TESSERACT_VERSION}}.xcframework.zip libtesseract.xcframework
+
+  build-tesseract-ios-xcframework:
+      cmds:
+        - task: clean-build-folder
+        - task: clean-sources
+        - task: build-tesseract-ios-simulator-framework
+        - task: clean-sources
+        - task: build-tesseract-ios-framework
+        - task: clean-sources
+        - |
+          xcodebuild -create-xcframework \
+            -framework {{.IOS_FRAMEWORK}} \
+            -framework {{.IOS_SIMULATOR_FRAMEWORK}} \
+            -output {{.SRC_DIR}}/libtesseract.xcframework
+      status:
+        - test -f {{.SRC_DIR}}/libtesseract.xcframework
 
   build-tesseract-xcframework:
     cmds:
@@ -372,7 +393,7 @@ tasks:
         mkdir -p {{.TESSERACT_SRC}}/{{.ARCH_NAME}}
         cd {{.TESSERACT_SRC}}/{{.ARCH_NAME}}
         ln -s {{.LEPTONICA_SRC}}/src/ leptonica
-        ../configure --host={{.HOST}} --prefix=`pwd` --enable-shared=no --disable-graphics
+        ../configure --host={{.HOST}} --prefix=`pwd` --enable-shared=no --disable-graphics --disable-legacy --without-curl
     status:
       - test -f {{.TESSERACT_SRC}}/{{.ARCH_NAME}}/Makefile
 
@@ -381,6 +402,7 @@ tasks:
     cmds:
       - |
         cd {{.TESSERACT_SRC}}
+        patch configure.ac ../patch/optional_libcurl.patch
         ./autogen.sh 2> /dev/null
     status:
       - test -f {{.TESSERACT_CONFIG}}

--- a/patch/optional_libcurl.patch
+++ b/patch/optional_libcurl.patch
@@ -1,0 +1,37 @@
+diff --git a/configure.ac b/configure.ac
+index 4637efc9..aa62b8b6 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -193,6 +193,10 @@ if test "$enable_opencl" = "yes"; then
+   ])
+ fi
+ 
++AC_ARG_WITH([curl],
++            AS_HELP_STRING([--with-curl],
++                           [Build with libcurl which supports processing an image URL @<:@default=check@:>@]),
++            [], [with_curl=check])
+ # Check whether to build with support for TensorFlow.
+ AC_ARG_WITH([tensorflow],
+   AS_HELP_STRING([--with-tensorflow],
+@@ -429,8 +433,19 @@ AC_CHECK_TYPES([mbstate_t],,, [#include "wchar.h"])
+ # Test auxiliary packages
+ # ----------------------------------------
+ 
+-PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl=true], [have_libcurl=false])
+-AM_CONDITIONAL([HAVE_LIBCURL], $have_libcurl)
++AM_CONDITIONAL([HAVE_LIBCURL], false)
++AS_IF([test "x$with_curl" != xno], [
++  PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl=true], [have_libcurl=false])
++  AM_CONDITIONAL([HAVE_LIBCURL], $have_libcurl)
++  if $have_libcurl; then
++    AC_DEFINE([HAVE_LIBCURL], [1], [Enable libcurl])
++  else
++    AS_IF([test "x$with_curl" != xcheck], [
++      AC_MSG_FAILURE(
++        [--with-curl was given, but test for libcurl failed])
++    ])
++  fi
++])
+ 
+ PKG_CHECK_MODULES([LEPTONICA], [lept >= 1.74], [have_lept=true], [have_lept=false])
+ if $have_lept; then


### PR DESCRIPTION
To compile Tesseract without libcurl support autogen options were backported from 5.0.1 tag
Additional task to build only for iOS were added.

<!-- Thanks for contributing to libtesseract! Before you submit your pull request, please make sure to check the following boxes by putting an x in the [ ] (don't: [x ], [ x], do: [x]) -->

### Checklist
- I've validated my changes against the following plaftorms:
  - [x] iOS - Deployment Target Version 11.0
  - [] macOS Catalyst - Deployment Target Version 10.15
  - [] macOS - Deployment Target Version 10.13
- [] I've updated the documentation if necessary.
- [] I've read the [README](https://github.com/SwiftyTesseract/libtesseract/blob/main/README.md)
- [] I've read the [Contribution Guidelines](https://github.com/SwiftyTesseract/libtesseract/blob/main/CONTRIBUTING.md)
- [] I've read the [Code of Conduct](https://github.com/SwiftyTesseract/libtesseract/blob/main/CODE_OF_CONDUCT.md)

### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
Dependencies were outdated. They contained security vulnerabilities among other issues.
In the spirit of using the latest stable I also updated Tesseract to 4.1.3.
In future if need arises for mine project I will follow with PR updating Tesseract to 5.x

### Description
<!-- Describe your changes in detail. -->

### Testing Steps
<!-- Steps, commands, or code used to test your changes. -->
<!-- Providing these will reduce the time needed for testing and review. -->